### PR TITLE
made sure transactions close and pooled connections work

### DIFF
--- a/crontabber/app.py
+++ b/crontabber/app.py
@@ -155,6 +155,8 @@ class StateDatabase(RequiredConfig):
                 "SELECT app_name FROM crontabber"
             ):
                 yield each[0]
+            connection.commit()  # must not leave transaction open, this
+                                 # may be a pooled or shared connection
 
     def __contains__(self, key):
         """return True if we have a job by this key"""

--- a/crontabber/connection_context.py
+++ b/crontabber/connection_context.py
@@ -4,6 +4,8 @@
 
 import socket
 import contextlib
+import threading
+
 import psycopg2
 import psycopg2.extensions
 
@@ -181,7 +183,7 @@ class ConnectionContextPooled(ConnectionContext):  # pragma: no cover
             name - a name as a string
         """
         if not name:
-            name = self.config.executor_identity()
+            name = threading.current_thread().getName()
         if name in self.pool:
             #self.config.logger.debug('connection: %s', name)
             return self.pool[name]

--- a/crontabber/generic_app.py
+++ b/crontabber/generic_app.py
@@ -101,10 +101,7 @@ class LoggerWrapper(object):
 
     #--------------------------------------------------------------------------
     def executor_identity(self):
-        try:
-            return " - %s - " % self.config.executor_identity()
-        except KeyError:
-            return " - %s - " % threading.currentThread().getName()
+        return " - %s - " % threading.currentThread().getName()
 
     #--------------------------------------------------------------------------
     def debug(self, message, *args, **kwargs):


### PR DESCRIPTION
the loop in StateDatabase did not commit its transaction, so when Pooled Connections were used, there was a deadlock when running tests.

In addition, there is no task executor (socorro's multithread/singlethread/greenlet controller) so there is no 'executor_identity' function.  I reverted that back to getting the thread name.  That allows this class to be used in a multithreaded context - even though we don't now want to - it's better to write safe code than not. 
