### PR TITLE
fixes overzealous mixin of transactional resources

### DIFF
--- a/crontabber/mixins.py
+++ b/crontabber/mixins.py
@@ -57,20 +57,20 @@ def with_transactional_resource(transactional_resource_class, resource_name):
             raise Exception(
                 '%s must have RequiredConfig as a base class' % cls
             )
-        if not hasattr(cls, 'required_config'):
-            cls.requried_config = Namespace()
-        cls.required_config.namespace(resource_name)
-        cls.required_config[resource_name].add_option(
+        new_req = cls.get_required_config()
+        new_req.namespace(resource_name)
+        new_req[resource_name].add_option(
             '%s_class' % resource_name,
             default=transactional_resource_class,
             from_string_converter=class_converter,
         )
-        cls.required_config[resource_name].add_option(
+        new_req[resource_name].add_option(
             '%s_transaction_executor_class' % resource_name,
             default='crontabber.transaction_executor.TransactionExecutor',
             doc='a class that will execute transactions',
             from_string_converter=class_converter,
         )
+        cls.required_config = new_req
 
         #------------------------------------------------------------------
         def new__init__(self, *args, **kwargs):

--- a/crontabber/tests/test_crontab_mixins.py
+++ b/crontabber/tests/test_crontab_mixins.py
@@ -116,3 +116,25 @@ class TestCrontabMixins(unittest.TestCase):
             def __init__(self, config):
                 self.config = config
         ok_(hasattr(Alpha, '_run_proxy'))
+
+    def test_no_over_propagation(self):
+
+
+        @ctm.with_postgres_transactions()
+        class Alpha(BaseCronApp):
+            required_config = Namespace()
+            required_config.add_option('a', default=0)
+
+
+        @ctm.with_transactional_resource(
+            mock.Mock(),
+            'queuing'
+        )
+        class Beta(BaseCronApp):
+            required_config = Namespace()
+            required_config.add_option('a', default=0)
+
+        ok_('database' in Alpha.get_required_config())
+        ok_('queuing' not in Alpha.get_required_config())
+        ok_('database' not in Beta.get_required_config())
+        ok_('queuing' in Beta.get_required_config())


### PR DESCRIPTION
I've discovered that the mixins are overworking. If we have jobs A, B and C, at they, repetitively require resources X, Y and Z, the mixins will set it up like this:

A -> X
B -> X, Y
C -> X, Y, Z

when it should be:

A -> X
B -> Y
C -> Z

this happens because the mixin decorators are using the 'required_config' directly rather than calling the 'get_required_config' method. This is a relatively benign problem as jobs with extra resources just ignore them. It makes for messy ini files, though.
