### PR TITLE
crontabber tests requires timezone=utc, fixes #15

### DIFF
--- a/crontabber/app.py
+++ b/crontabber/app.py
@@ -141,8 +141,6 @@ class JobStateDatabase(RequiredConfig):
             CREATE_CRONTABBER_LOG_SQL
         )
 
-
-
     def has_data(self):
         try:
             return bool(self.transaction_executor(


### PR DESCRIPTION
@twobraids r?

With this change, developers no longer need to have UTC configured in their local PG. 

I need to fix mine personally because of socorro but that's another story. 
