### PR TITLE
renamed postgres specific decorators

### DIFF
--- a/crontabber/mixins.py
+++ b/crontabber/mixins.py
@@ -114,6 +114,11 @@ def with_resource_connection_as_argument(resource_name):
     _run_proxy method that passes a databsase connection as a context manager
     into the CronApp's run method.  The connection will automatically be closed
     when the ConApp's run method ends.
+
+    In order for this dectorator to function properly, it must be used in
+    conjunction with previous dectorator, "with_transactional_resource" or
+    equivalent.  This decorator depends on the mechanims added by that
+    decorator.
     """
     connection_factory_attr_name = '%s_connection_factory' % resource_name
 
@@ -139,6 +144,10 @@ def with_single_transaction(resource_name):
     connection will automatically be commited.  Any abnormal exit from 'run'
     will result in the connnection being rolledback.
 
+    In order for this dectorator to function properly, it must be used in
+    conjunction with previous dectorator, "with_transactional_resource" or
+    equivalent.  This decorator depends on the mechanims added by that
+    decorator.
     """
     transaction_executor_attr_name = "%s_transaction_executor" % resource_name
 
@@ -194,9 +203,9 @@ def with_subprocess(cls):
 #     self.database_transaction_executor
 # when using this definition as a class decorator, it is necessary to use
 # parenthesis as it is a function call:
-#    @with_postgres_transactions()
+#    @using_postgres()
 #    class MyClass ...
-with_postgres_transactions = partial(
+using_postgres = partial(
     with_transactional_resource,
     'crontabber.connection_factory.ConnectionFactory',
     'database'
@@ -209,12 +218,14 @@ with_postgres_transactions = partial(
 # completes.
 # when using this definition as a class decorator, it is necessary to use
 # parenthesis as it is a function call:
-#    @with_postgres_transactions()
+#    @using_postgres()
+#    @with_postgres_connection_as_argument()
 #    class MyClass ...
 with_postgres_connection_as_argument = partial(
     with_resource_connection_as_argument,
     'database'
 )
+
 #------------------------------------------------------------------------------
 # this class decorator adds a _run_proxy method to the class that will
 # call the class' run method in the context of a database transaction.  It
@@ -223,9 +234,15 @@ with_postgres_connection_as_argument = partial(
 # escaping the run function will result in a "rollback"
 # when using this definition as a class decorator, it is necessary to use
 # parenthesis as it is a function call:
-#    @with_postgres_transactions()
+#    @using_postgres()
+#    @as_single_postgres_transaction()
 #    class MyClass ...
-with_single_postgres_transaction = partial(
+as_single_postgres_transaction = partial(
     with_single_transaction,
     'database'
 )
+
+
+# backwards compatibility
+with_postgres_transactions = using_postgres
+with_single_postgres_transaction = as_single_postgres_transaction

--- a/crontabber/tests/test_crontab_mixins.py
+++ b/crontabber/tests/test_crontab_mixins.py
@@ -94,8 +94,8 @@ class TestCrontabMixins(unittest.TestCase):
         ok_(hasattr(Alpha, '_run_proxy'))
         ok_(hasattr(Alpha, 'run_process'))
 
-    def test_with_postgres_transactions(self):
-        @ctm.with_postgres_transactions()
+    def test_using_postgres(self):
+        @ctm.using_postgres()
         class Alpha(BaseCronApp):
             def __init__(self, config):
                 self.config = config
@@ -110,7 +110,7 @@ class TestCrontabMixins(unittest.TestCase):
         )
 
     def test_with_postgres_connection_as_argument(self):
-        @ctm.with_postgres_transactions()
+        @ctm.using_postgres()
         @ctm.with_postgres_connection_as_argument()
         class Alpha(BaseCronApp):
             def __init__(self, config):
@@ -118,9 +118,7 @@ class TestCrontabMixins(unittest.TestCase):
         ok_(hasattr(Alpha, '_run_proxy'))
 
     def test_no_over_propagation(self):
-
-
-        @ctm.with_postgres_transactions()
+        @ctm.using_postgres()
         class Alpha(BaseCronApp):
             required_config = Namespace()
             required_config.add_option('a', default=0)

--- a/crontabber/tests/test_crontabber.py
+++ b/crontabber/tests/test_crontabber.py
@@ -20,9 +20,9 @@ from crontabber.datetimeutil import utc_now
 from configman import Namespace
 from crontabber.mixins import (
     as_backfill_cron_app,
-    with_postgres_transactions,
+    using_postgres,
     with_postgres_connection_as_argument,
-    with_single_postgres_transaction
+    as_single_postgres_transaction
 )
 
 from .base import IntegrationTestCaseBase
@@ -2030,7 +2030,7 @@ class _Job(base.BaseCronApp):
         self.config.logger.info("Ran %s" % self.__class__.__name__)
 
 
-@with_postgres_transactions()
+@using_postgres()
 @with_postgres_connection_as_argument()
 class _PGJob(_Job):
 
@@ -2038,8 +2038,8 @@ class _PGJob(_Job):
         _Job.run(self)
 
 
-@with_postgres_transactions()
-@with_single_postgres_transaction()
+@using_postgres()
+@as_single_postgres_transaction()
 class _PGTransactionManagedJob(_Job):
 
     def run(self, connection):
@@ -2205,7 +2205,7 @@ class SlowBackfillJob(_BackfillJob):
         super(SlowBackfillJob, self).run(date)
 
 
-@with_postgres_transactions()
+@using_postgres()
 @with_postgres_connection_as_argument()
 @as_backfill_cron_app
 class PGBackfillJob(_Job):
@@ -2227,7 +2227,7 @@ class PGBackfillJob(_Job):
         )
 
 
-@with_postgres_transactions()
+@using_postgres()
 @with_postgres_connection_as_argument()
 @as_backfill_cron_app
 class PostgresBackfillSampleJob(_Job):

--- a/docs/user/moreadvancedapps.rst
+++ b/docs/user/moreadvancedapps.rst
@@ -103,7 +103,7 @@ with the correct configuration to automatically connect with Postgres and
 handle transactions automatically.  The three decorators provide differing
 levels of automation so that you can choose how much control you want.
 
-@with_postgres_transactions()
+@using_postgres()
 .............................
 
 This decorator tells crontabber that you want to use postgres by adding to
@@ -136,7 +136,7 @@ then the transaction will be automatically rolled back.
 
 .. code-block:: python
 
-    @with_postgres_transactions()
+    @using_postgres()
     class MyPGApp(BaseCronApp):
         def execute_lots_of_sql(connection, sql_in_a_list):
             '''run multiple sql statements in a single transaction'''
@@ -164,7 +164,7 @@ connection as its first argument:
 
 .. code-block:: python
 
-    @with_postgres_transactions()
+    @using_postgres()
     @with_postgres_connection_as_argument()
     class MyCrontabberApp(BaseCronApp):
         app_name = 'postgres-enabled-app'
@@ -184,7 +184,7 @@ You still have the transaction manager available if you want to use it.  Note,
 however, that it will acquire its own database connection and not use the one
 that was passed into your run function.  Don't deadlock yourself.
 
-@with_single_postgres_transaction()
+@as_single_postgres_transaction()
 ...................................
 
 This decorator gives you the most automation.  It considers your entire run
@@ -196,8 +196,8 @@ being raised, the connection will be rolled back automatically.
 
 .. code-block:: python
 
-    @with_postgres_transactions()
-    @with_single_postgres_transaction()
+    @using_postgres()
+    @as_single_postgres_transaction()
     class MyCrontabberApp(BaseCronApp):
         app_name = 'postgres-enabled-app'
 


### PR DESCRIPTION
the names for the postgres specific decorators were awkward.  Now they read like sentences and there for better explain themselves.  
