### PR TITLE
simplify pg connection parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - python setup.py install
 
 script:
-    - database_username=postgres database_name=travis_ci_test nosetests crontabber
+    - user=postgres dbname=travis_ci_test nosetests crontabber
 
 notifications:
     irc:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Next, in the root directory of the project create a file called
 
 ```
 [crontabber]
-database_username=myusername
-database_password=mypassword
-database_name=test_crontabber
+user=myusername
+password=mypassword
+dbname=test_crontabber
 ```
 
 To start all the tests run:

--- a/crontabber/connection_factory.py
+++ b/crontabber/connection_factory.py
@@ -22,34 +22,34 @@ class ConnectionFactory(RequiredConfig):
     # to a database.
     required_config = Namespace()
     required_config.add_option(
-        name='database_hostname',
+        name='host',
         default='localhost',
         doc='the hostname of the database',
         reference_value_from='resource.postgresql',
     )
     required_config.add_option(
-        name='database_name',
+        name='dbname',
         default='',
         doc='the name of the database',
         reference_value_from='resource.postgresql',
     )
     required_config.add_option(
-        name='database_port',
+        name='port',
         default=5432,
         doc='the port for the database',
         reference_value_from='resource.postgresql',
     )
     required_config.add_option(
-        name='database_username',
+        name='user',
         default='',
         doc='the name of the user within the database',
-        reference_value_from='secrets.postgresql',
+        reference_value_from='resource.postgresql',
     )
     required_config.add_option(
-        name='database_password',
+        name='password',
         default='',
         doc="the user's database password",
-        reference_value_from='secrets.postgresql',
+        reference_value_from='resource.postgresql',
     )
 
     # clients of this class may need to detect Exceptions raised in the
@@ -73,11 +73,11 @@ class ConnectionFactory(RequiredConfig):
         if local_config is None:
             local_config = config
         self.dsn = (
-            "host=%(database_hostname)s "
-            "dbname=%(database_name)s "
-            "port=%(database_port)s "
-            "user=%(database_username)s "
-            "password=%(database_password)s"
+            "host=%(host)s "
+            "dbname=%(dbname)s "
+            "port=%(port)s "
+            "user=%(user)s "
+            "password=%(password)s"
             % local_config
         )
         self.operational_exceptions = (

--- a/crontabber/generic_app.py
+++ b/crontabber/generic_app.py
@@ -12,9 +12,18 @@ import logging.handlers
 import functools
 import signal
 
+from configman import (
+    ConfigurationManager,
+    Namespace,
+    RequiredConfig,
+    command_line,
+    ConfigFileFutureProxy,
+    class_converter
+)
+from configman.dotdict import DotDictWithAcquisition
 
-from configman import ConfigurationManager, Namespace, RequiredConfig
-from configman.converters import class_converter
+environment = DotDictWithAcquisition(os.environ)
+environment.always_ignore_mismatches = True
 
 
 #==============================================================================
@@ -221,6 +230,14 @@ def _do_main(
     config_path=None,
     config_manager_cls=ConfigurationManager
 ):
+    if values_source_list is None:
+        values_source_list = [
+            ConfigFileFutureProxy,
+            environment,
+            command_line
+        ]
+
+
     global restart
     restart = False
     if isinstance(initial_app, basestring):

--- a/crontabber/mixins.py
+++ b/crontabber/mixins.py
@@ -29,7 +29,11 @@ def as_backfill_cron_app(cls):
 
 
 #==============================================================================
-def with_transactional_resource(transactional_resource_class, resource_name):
+def with_transactional_resource(
+    transactional_resource_class,
+    resource_name,
+    reference_value_from=None
+):
     """a class decorator for Crontabber Apps.  This decorator will give access
     to a resource connection source.  Configuration will be automatically set
     up and the cron app can expect to have attributes:
@@ -63,12 +67,14 @@ def with_transactional_resource(transactional_resource_class, resource_name):
             '%s_class' % resource_name,
             default=transactional_resource_class,
             from_string_converter=class_converter,
+            reference_value_from=reference_value_from,
         )
         new_req[resource_name].add_option(
             '%s_transaction_executor_class' % resource_name,
             default='crontabber.transaction_executor.TransactionExecutor',
             doc='a class that will execute transactions',
             from_string_converter=class_converter,
+            reference_value_from=reference_value_from
         )
         cls.required_config = new_req
 
@@ -208,7 +214,8 @@ def with_subprocess(cls):
 using_postgres = partial(
     with_transactional_resource,
     'crontabber.connection_factory.ConnectionFactory',
-    'database'
+    'database',
+    'resource.postgresql'
 )
 #------------------------------------------------------------------------------
 # this class decorator adds a _run_proxy method to the class that will

--- a/crontabber/tests/test_crontab_mixins.py
+++ b/crontabber/tests/test_crontab_mixins.py
@@ -12,6 +12,8 @@ import crontabber.mixins as ctm
 from crontabber.connection_factory import ConnectionFactory
 from crontabber.transaction_executor import TransactionExecutor
 
+from crontabber.generic_app import environment
+
 
 class FakeResourceClass(object):
     pass
@@ -60,7 +62,7 @@ class TestCrontabMixins(unittest.TestCase):
         )
         cm = ConfigurationManager(
             definition_source=[Alpha.get_required_config(), ],
-            values_source_list=[],
+            values_source_list=[environment],
             argv_source=[],
         )
         config = cm.get_config()

--- a/crontabber/tests/test_transaction_executor.py
+++ b/crontabber/tests/test_transaction_executor.py
@@ -18,6 +18,7 @@ from crontabber.dbapi2_util import (
     SQLDidNotReturnSingleValue,
     SQLDidNotReturnSingleRow
 )
+from crontabber.generic_app import environment
 
 
 class SomeError(Exception):
@@ -103,7 +104,7 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[],
+            values_source_list=[environment],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -144,7 +145,7 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[],
+            values_source_list=[environment],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -183,7 +184,7 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[],
+            values_source_list=[environment],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -223,7 +224,10 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[{'backoff_delays': [2, 4, 6, 10, 15]}],
+            values_source_list=[
+                environment,
+                {'backoff_delays': [2, 4, 6, 10, 15]}
+            ],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -284,7 +288,10 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[{'backoff_delays': [2, 4, 6, 10, 15]}],
+            values_source_list=[
+                environment,
+                {'backoff_delays': [2, 4, 6, 10, 15]}
+            ],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -346,7 +353,10 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[{'backoff_delays': [2, 4, 6, 10, 15]}],
+            values_source_list=[
+                environment,
+                {'backoff_delays': [2, 4, 6, 10, 15]}
+            ],
             argv_source=[]
         )
         with config_manager.context() as config:
@@ -441,7 +451,7 @@ class TestTransactionExecutor(unittest.TestCase):
             app_name='testapp',
             app_version='1.0',
             app_description='app description',
-            values_source_list=[],
+            values_source_list=[environment],
             argv_source=[]
         )
         with config_manager.context() as config:

--- a/docs/developer/runningtests.rst
+++ b/docs/developer/runningtests.rst
@@ -19,9 +19,9 @@ Next, in the root directory of the project create a file called
 
 
     [crontabber]
-    database_username=myusername
-    database_password=mypassword
-    database_name=test_crontabber
+    user=myusername
+    password=mypassword
+    dbname=test_crontabber
 
 To start all the tests run::
 

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -33,7 +33,7 @@ all default settings left commented out.
 
 Before we can start writing our first app we need to set credentials to
 connect to Postgres. Open your newly created ``crontabber.ini`` file and look
-for the settings: ``database_name``, ``database_username`` and ``database_password``.
+for the settings: ``dbname``, ``user`` and ``password``.
 Perhaps you want to create a new database first to test against::
 
     createdb crontabber
@@ -41,9 +41,9 @@ Perhaps you want to create a new database first to test against::
 Depending on how you have set up Postgres server you might need to supply a
 username and password. Proceed to edit your ``crontabber.ini`` and set::
 
-    database_name=crontabber
-    database_username=myusername
-    database_password=mypostgrespassword
+    dbname=crontabber
+    user=myusername
+    password=mypostgrespassword
 
 You can see where the default settings are set and you can change those lines.
 Let's try to see if it works::

--- a/exampleapp/README.md
+++ b/exampleapp/README.md
@@ -11,8 +11,8 @@
 2. Now you need to edit crontabber.ini. It can be quite scary.
    The first two things to do are:
 
-   1. Find the settings `database_name`, `database_user`,
-   `database_password` etc. and uncomment them accordingly.
+   1. Find the settings `dbname`, `user`,
+   `password` etc. and uncomment them accordingly.
 
    2. The `jobs` setting is the most important one. For now, change it
    to `foo.FooCronApp|10m`


### PR DESCRIPTION
this PR simplifies the PG connection credentials to be identical with the default PG names.
also - allow the environment to have "acquisition" so that the simplified connection parameters can be specified in the environment without qualifications.

includes doc changes!

NOTE: this doesn't depend on any particular version of configman.
NOTE: there's some commented out stuff to help envision the scope of the change.
