### PR TITLE
render long_description from markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,16 @@ def find_tests_require():
             if x.strip() and not x.startswith('#')]
 
 
-README = read('README.md')
+try:
+    import pypandoc
+    README = pypandoc.convert('README.md', 'rst')
+except (IOError, ImportError, OSError, RuntimeError) as x:
+    import sys
+    print >> sys.stderr, "Unable to convert README.md to reStructuredText"
+    print >> sys.stderr, sys.exc_info()[0]
+    print >> sys.stderr, x
+    README = read('README.md')
+
 
 setup(
     name='crontabber',


### PR DESCRIPTION
@twobraids r?

What this does is that it converts the markdown text to reStructuredText when you run `python setup.py sdist` so that the long_description in the `PKG-INFO` file is in rst format. 

I like using Markdown because it's more important, to me, how the README looks on github than it does on pypi. However, pypi does not support Markdown and it's not simply a matter of looking at the extension of the readme file because what really matters is the `long_description` value sent to the `setup()` function and at that point it looses the `.md` extension stuff. 

There's a caveat here though. You have to install `pypandoc` and `pandoc` yourself on the machine you're building the sdist from. All `pypandoc` does is that it calls on, on the command line, to `pandoc`. 
Basically, if the person who runs the `python setup.py sdist upload` doesn't have those things installed, the pypi README will look a bit odd but it won't look any worse than it does today. 
