### PR TITLE
KeyError when switching timezone of test database

### DIFF
--- a/crontabber/tests/base.py
+++ b/crontabber/tests/base.py
@@ -11,15 +11,14 @@ import unittest
 from collections import Sequence, Mapping, defaultdict
 
 import mock
-import psycopg2
 from nose.plugins.attrib import attr
 from nose.tools import eq_
 
 import configman
-from configman.dotdict import DotDictWithAcquisition
 
 from crontabber import app
 from crontabber.generic_app import environment
+
 
 class TestCaseBase(unittest.TestCase):
 
@@ -135,7 +134,7 @@ class IntegrationTestCaseBase(TestCaseBase):
             tz, = cursor.fetchone()
             if tz != 'UTC':
                 cursor.execute("""
-                   ALTER DATABASE %(database_name)s SET TIMEZONE TO UTC;
+                   ALTER DATABASE %(dbname)s SET TIMEZONE TO UTC;
                 """ % self.config.crontabber)
             failed = False
         finally:


### PR DESCRIPTION
Sorry about the coincidental flake8 fixes. 

This I have no idea how to test this. When you change a database's timezone, it doesn't immediately reflect until you re-connect. 
I.e.
```
test_crontabber=# show timezone;
 TimeZone
----------
 UTC
(1 row)

test_crontabber=# alter database test_crontabber set timezone to 'US/Eastern';
ALTER DATABASE
test_crontabber=# show timezone;
 TimeZone
----------
 UTC
(1 row)
```

One possible solution would be to NOT make this part of the test base class. Perhaps some check that if it fails, it instructs you to what SQL you need to execute manually. 

However, the change made in this PR just fixes it. The first time you get an error, it gets correct and simply running the tests again fixes everything. 